### PR TITLE
Don't validate information set by text

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,6 @@
+commit-message-incrementing: Disabled
+ignore:
+  sha:
+    - 717e38f8897218bd5cee0446bc4c70423b3b56eb
+    - 51dcc960438b33b43af3dce00f17f0e94ad66925
+    - c0d27c0204080830655fb211ca367a378cf54cf8

--- a/src/Internal/SecurityTextContainer.cs
+++ b/src/Internal/SecurityTextContainer.cs
@@ -58,6 +58,10 @@ namespace CHG.Extensions.Security.Txt.Internal
 		/// </summary>
 		public void Validate()
 		{
+			// Don't validate information set by text
+			if (!string.IsNullOrEmpty(Text))
+				return;
+
 			if (!string.IsNullOrEmpty(Contact))
 				ValidateContact();
 			else

--- a/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextContainerTests.cs
+++ b/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextContainerTests.cs
@@ -144,6 +144,15 @@ namespace CHG.Extensions.Security.Txt.Tests
             }
 
             [Test]
+            public void Throws_No_Exception_For_Missing_Contact_When_Set_By_Text()
+            {
+				_container.Contact = null;
+				_container.Text = "Contact: mailto:test@example.com.au\r\n";
+                Action action = () => _container.Validate();
+                action.Should().NotThrow();
+            }
+
+            [Test]
             public void Throws_No_Exception_If_Contact_Is_Valid_Email_Address()
             {
                 _container.Contact = "mailto:security@example.com";


### PR DESCRIPTION
Fixes #28 

Ignore validation when security information is set by text, because it's not parsed at the moment.