### PR TITLE
Add option to define new line style

### DIFF
--- a/src/Internal/SecurityTextContainer.cs
+++ b/src/Internal/SecurityTextContainer.cs
@@ -47,7 +47,7 @@ namespace CHG.Extensions.Security.Txt.Internal
 			if (!string.IsNullOrEmpty(Text))
 				return;
 
-			ValidateContact();			
+			ValidateContact();
 			ValidateAcknowledgments();
 			ValidateEncryption();
 			ValidateHiring();
@@ -59,49 +59,49 @@ namespace CHG.Extensions.Security.Txt.Internal
 		private void AddPermission(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Permission))
-				builder.AppendLine($"Permission: {Permission}");
+				AppendLine(builder, $"Permission: {Permission}");
 		}
 
 		private void AddHiring(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Hiring))
-				builder.AppendLine($"Hiring: {Hiring}");
+				AppendLine(builder, $"Hiring: {Hiring}");
 		}
 
 		private void AddAcknowledgments(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Acknowledgments))
-				builder.AppendLine($"Acknowledgments: {Acknowledgments}");
+				AppendLine(builder, $"Acknowledgments: {Acknowledgments}");
 		}
 
 		private void AddPolicy(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Policy))
-				builder.AppendLine($"Policy: {Policy}");
+				AppendLine(builder, $"Policy: {Policy}");
 		}
 
 		private void AddSignature(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Signature))
-				builder.AppendLine($"Signature: {Signature}");
+				AppendLine(builder, $"Signature: {Signature}");
 		}
 
 		private void AddEncryption(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Encryption))
-				builder.AppendLine($"Encryption: {Encryption}");
+				AppendLine(builder, $"Encryption: {Encryption}");
 		}
 
 		private void AddContact(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Contact))
-				builder.Append(ExtractMultiple("Contact: ", Contact));
+				builder.Append(ExtractMultiple("Contact: ", Contact, NewLineString));
 		}
 
 		private void AddIntroduction(StringBuilder builder)
 		{
 			if (!string.IsNullOrEmpty(Introduction))
-				builder.AppendLine(CreateComment(Introduction));
+				AppendLine(builder, CreateComment(Introduction));
 		}
 
 		/// <summary>
@@ -254,32 +254,41 @@ namespace CHG.Extensions.Security.Txt.Internal
 			}
 		}
 
+		private string CreateComment(string value)
+		{
+			return CreateComment(value, NewLineString);
+		}
+
 		/// <summary>
 		/// Creates a comment from the given value.
 		/// </summary>
 		/// <param name="value">The value.</param>
 		/// <returns></returns>
-		internal static string CreateComment(string value)
+		internal static string CreateComment(string value, string newLineString)
 		{
 			if (string.IsNullOrEmpty(value))
 				return string.Empty;
 
 			return COMMENT_PREFIX +
-				value.Replace("\r\n", "~~")
-				.Replace("\r", "~~")
-				.Replace("\n", "~~")
-				.Replace("~~", Environment.NewLine + COMMENT_PREFIX);
+				value.Replace("\r\n", "\n")
+				.Replace("\r", "\n")
+				.Replace("\n", newLineString + COMMENT_PREFIX);
 		}
 
-		private static string ExtractMultiple(string directive, string value)
+		private static string ExtractMultiple(string directive, string value, string newLineString)
 		{
 			var values = value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
 			var builder = new StringBuilder();
 
 			foreach (var item in values)
-				builder.AppendLine($"{directive}{item}");
+				builder.Append($"{directive}{item}").Append(newLineString);
 
 			return builder.ToString();
+		}
+
+		private void AppendLine(StringBuilder builder, string value)
+		{
+			builder.Append(value).Append(NewLineString);
 		}
 
 		/// <summary>
@@ -339,6 +348,11 @@ namespace CHG.Extensions.Security.Txt.Internal
 		/// Gets or sets whether the values should be validated
 		/// </summary>
 		public bool ValidateValues { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets the string to define a new line
+		/// </summary>
+		public string NewLineString { get; set; } = Environment.NewLine;
 
 	}
 }

--- a/src/SecurityTextBuilder.cs
+++ b/src/SecurityTextBuilder.cs
@@ -213,12 +213,32 @@ namespace CHG.Extensions.Security.Txt
             _container.Introduction = value;
             return this;
         }
-        
-        /// <summary>
-        /// Builds the security information text
-        /// </summary>
-        /// <returns></returns>
-        public SecurityTextContainer GetContainer()
+
+		/// <summary>
+		/// Use Carriage Return And Line Feed (CR LF) as new line style
+		/// </summary>
+		/// <returns></returns>
+		public SecurityTextBuilder UseWindowsStyleNewLine()
+		{
+			_container.NewLineString = "\r\n";
+			return this;
+		}
+
+		/// <summary>
+		/// Use Line Feed (LF) as new line style
+		/// </summary>
+		/// <returns></returns>
+		public SecurityTextBuilder UseUnixStyleNewLine()
+		{
+			_container.NewLineString = "\n";
+			return this;
+		}
+
+		/// <summary>
+		/// Builds the security information text
+		/// </summary>
+		/// <returns></returns>
+		public SecurityTextContainer GetContainer()
         {
             return _container;
         }

--- a/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextBuilderTests.cs
+++ b/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextBuilderTests.cs
@@ -308,5 +308,25 @@ namespace CHG.Extensions.Security.Txt.Tests
                     .GetContainer().Build().Should().Be("# The ACME Security information.");
             }
         }
-    }
+
+		public class UseWindowsStyleNewLineMethod: SecurityTextBuilderTests
+		{
+			[Test]
+			public void Sets_Line_Style()
+			{
+				_builder.UseWindowsStyleNewLine()
+					.GetContainer().NewLineString.Should().Be("\r\n");
+			}
+		}
+
+		public class UseUnixStyleNewLineMethod : SecurityTextBuilderTests
+		{
+			[Test]
+			public void Sets_Line_Style()
+			{
+				_builder.UseUnixStyleNewLine()
+					.GetContainer().NewLineString.Should().Be("\n");
+			}
+		}
+	}
 }

--- a/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextContainerTests.cs
+++ b/tests/CHG.Extensions.Security.Txt.Tests/SecurityTextContainerTests.cs
@@ -45,10 +45,12 @@ namespace CHG.Extensions.Security.Txt.Tests
                 _container.Build().Should().Be("Test\n123");
             }
 
-            [Test]
-            public void Returns_Security_Infos()
+            [TestCase("\n")]
+			[TestCase("\r\n")]
+			public void Returns_Security_Infos(string newLineStyle)
             {
-                _container.Contact = "mailto:security@example.com";
+				_container.NewLineString = newLineStyle;
+				_container.Contact = "mailto:security@example.com";
                 _container.Encryption = "https://example.com/pgp-key.txt";
                 _container.Hiring = "https://example.com/jobs.html";
                 _container.Acknowledgments = "https://example.com/hall-of-fame.html";
@@ -57,13 +59,13 @@ namespace CHG.Extensions.Security.Txt.Tests
                 _container.Introduction = "The ACME Security information.";
                 _container.Permission = "none";
 
-                _container.Build().Should().Be("# The ACME Security information." + Environment.NewLine +
-"Contact: mailto:security@example.com" + Environment.NewLine +
-"Encryption: https://example.com/pgp-key.txt" + Environment.NewLine +
-"Signature: https://example.com/.well-known/security.txt.sig" + Environment.NewLine +
-"Policy: https://example.com/security-policy.html" + Environment.NewLine +
-"Acknowledgments: https://example.com/hall-of-fame.html" + Environment.NewLine +
-"Hiring: https://example.com/jobs.html" + Environment.NewLine +
+                _container.Build().Should().Be("# The ACME Security information." + newLineStyle +
+"Contact: mailto:security@example.com" + newLineStyle +
+"Encryption: https://example.com/pgp-key.txt" + newLineStyle +
+"Signature: https://example.com/.well-known/security.txt.sig" + newLineStyle +
+"Policy: https://example.com/security-policy.html" + newLineStyle +
+"Acknowledgments: https://example.com/hall-of-fame.html" + newLineStyle +
+"Hiring: https://example.com/jobs.html" + newLineStyle +
 "Permission: none");
             }
         }
@@ -73,27 +75,33 @@ namespace CHG.Extensions.Security.Txt.Tests
             [Test]
             public void Returns_Empty_For_EmptyValue()
             {
-                SecurityTextContainer.CreateComment("").Should().BeEmpty();
+                SecurityTextContainer.CreateComment("", Environment.NewLine).Should().BeEmpty();
             }
 
             [Test]
             public void Returns_Empty_For_Null_Value()
             {
-                SecurityTextContainer.CreateComment(null).Should().BeEmpty();
+                SecurityTextContainer.CreateComment(null, Environment.NewLine).Should().BeEmpty();
             }
 
             [Test]
             public void Returns_Single_Line()
             {
-                SecurityTextContainer.CreateComment("test").Should().Be("# test");
+                SecurityTextContainer.CreateComment("test", Environment.NewLine).Should().Be("# test");
             }
 
             [Test]
             public void Returns_Multiline_With_Prefix()
             {
-                SecurityTextContainer.CreateComment("test\r\nother line").Should().Be("# test\r\n# other line");
+                SecurityTextContainer.CreateComment("test\r\nother line", Environment.NewLine).Should().Be("# test\r\n# other line");
             }
-        }
+
+			[Test]
+			public void Returns_Multiline_With_Prefix_With_Mixed_NewLine_Style()
+			{
+				SecurityTextContainer.CreateComment("test\r\nother line\nanother line", Environment.NewLine).Should().Be("# test\r\n# other line\r\n# another line");
+			}
+		}
 
         public class ValidateMethod : SecurityTextContainerTests
         {


### PR DESCRIPTION
Fixes #35 

Add option to define whether to use Windows (CR\LF) or Unix (LF) style for new lines.